### PR TITLE
Feature rollups 2

### DIFF
--- a/google-tests/unit-tests/CMakeLists.txt
+++ b/google-tests/unit-tests/CMakeLists.txt
@@ -5,3 +5,7 @@ Project(UnitTests)
 add_subdirectory(simulation_data)
 add_subdirectory(simulation_results)  
 add_subdirectory(simulation_runner)
+
+if(SOLTRACE_BUILD_GUI)
+    add_subdirectory(gui)
+endif()

--- a/google-tests/unit-tests/gui/CMakeLists.txt
+++ b/google-tests/unit-tests/gui/CMakeLists.txt
@@ -1,10 +1,17 @@
 Project(GUIUnitTests)
 
-find_package(Qt6 6.11 REQUIRED COMPONENTS Core)
+find_package(Qt6 6.11 REQUIRED COMPONENTS
+    Core Gui Quick Quick3D Widgets Graphs Concurrent
+)
 
 set(GUI_UNIT_TEST_SRC
+    ../../../gui/src/database/entity.h
+    ../../../gui/src/database/components.cpp
     ../../../gui/src/database/conversion.cpp
+    ../../../gui/src/database/database.cpp
+    ../../../gui/src/database/database_notification.cpp
     conversion_test.cpp
+    database_roundtrip_test.cpp
 )
 
 add_executable(GUIUnitTests
@@ -15,16 +22,33 @@ target_include_directories(GUIUnitTests
     PRIVATE
         ../../../gui/src
         ../../../coretrace/simulation_data
+        ../../../coretrace/simulation_results
+        ../../../coretrace/simulation_runner
+        ../../../coretrace/simulation_runner/native_runner
 )
 
 target_link_libraries(GUIUnitTests
     PRIVATE
         Qt6::Core
+        Qt6::Gui
+        Qt6::Quick
+        EnTT
+        magic_enum
         simdata
+        simresult
+        native_runner
         GTest::gtest_main
 )
 
-set_target_properties(GUIUnitTests PROPERTIES CXX_STANDARD 20)
+target_compile_definitions(GUIUnitTests
+    PRIVATE
+        SOLTRACE_REPO_ROOT="${CMAKE_SOURCE_DIR}"
+)
+
+set_target_properties(GUIUnitTests PROPERTIES
+    AUTOMOC ON
+    CXX_STANDARD 20
+)
 
 if (ENABLE_COVERAGE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_link_options(GUIUnitTests PRIVATE --coverage)

--- a/google-tests/unit-tests/gui/CMakeLists.txt
+++ b/google-tests/unit-tests/gui/CMakeLists.txt
@@ -1,0 +1,38 @@
+Project(GUIUnitTests)
+
+find_package(Qt6 6.11 REQUIRED COMPONENTS Core)
+
+set(GUI_UNIT_TEST_SRC
+    ../../../gui/src/database/conversion.cpp
+    conversion_test.cpp
+)
+
+add_executable(GUIUnitTests
+    ${GUI_UNIT_TEST_SRC}
+)
+
+target_include_directories(GUIUnitTests
+    PRIVATE
+        ../../../gui/src
+        ../../../coretrace/simulation_data
+)
+
+target_link_libraries(GUIUnitTests
+    PRIVATE
+        Qt6::Core
+        simdata
+        GTest::gtest_main
+)
+
+set_target_properties(GUIUnitTests PROPERTIES CXX_STANDARD 20)
+
+if (ENABLE_COVERAGE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_link_options(GUIUnitTests PRIVATE --coverage)
+    target_link_libraries(GUIUnitTests PRIVATE gcov)
+endif()
+
+if(UNIX)
+    target_link_libraries(GUIUnitTests PRIVATE pthread)
+endif()
+
+add_test(NAME GUIUnitTests COMMAND GUIUnitTests)

--- a/google-tests/unit-tests/gui/conversion_test.cpp
+++ b/google-tests/unit-tests/gui/conversion_test.cpp
@@ -1,0 +1,58 @@
+#include "database/conversion.h"
+
+#include <gtest/gtest.h>
+
+#define GLM_ENABLE_EXPERIMENTAL 1
+
+#include <glm/geometric.hpp>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtx/quaternion.hpp>
+#include <glm/vec3.hpp>
+
+#include <cmath>
+
+namespace {
+
+constexpr double kTolerance = 1.0e-12;
+
+void expect_vec_near(glm::dvec3 const& actual,
+                     glm::dvec3 const& expected,
+                     double            tolerance = kTolerance) {
+    EXPECT_NEAR(actual.x, expected.x, tolerance);
+    EXPECT_NEAR(actual.y, expected.y, tolerance);
+    EXPECT_NEAR(actual.z, expected.z, tolerance);
+}
+
+bool same_rotation(glm::dquat const& a,
+                   glm::dquat const& b,
+                   double            tolerance = kTolerance) {
+    return glm::length(a - b) <= tolerance ||
+           glm::length(a + b) <= tolerance;
+}
+
+} // namespace
+
+TEST(DirRollToQuat, IdentityForZeroDirection) {
+    auto q = db::dir_roll_to_quat({ 0.0, 0.0, 0.0 }, 1.25);
+
+    EXPECT_TRUE(same_rotation(q, glm::identity<glm::dquat>()));
+}
+
+TEST(DirRollToQuat, MapsLocalForwardToDirection) {
+    glm::dvec3 direction = glm::normalize(glm::dvec3(1.0, 2.0, 3.0));
+
+    auto q = db::dir_roll_to_quat(direction, 0.0);
+
+    expect_vec_near(q * glm::dvec3(0.0, 0.0, 1.0), direction);
+}
+
+TEST(DirRollToQuat, AppliesRollAroundDirection) {
+    glm::dvec3 direction = glm::dvec3(0.0, 0.0, 1.0);
+    double     roll      = glm::half_pi<double>();
+
+    auto q = db::dir_roll_to_quat(direction, roll);
+
+    expect_vec_near(q * glm::dvec3(0.0, 0.0, 1.0), direction);
+    expect_vec_near(q * glm::dvec3(0.0, 1.0, 0.0),
+                    glm::dvec3(-1.0, 0.0, 0.0));
+}

--- a/google-tests/unit-tests/gui/conversion_test.cpp
+++ b/google-tests/unit-tests/gui/conversion_test.cpp
@@ -1,5 +1,7 @@
 #include "database/conversion.h"
 
+#include "single_element.hpp"
+
 #include <gtest/gtest.h>
 
 #define GLM_ENABLE_EXPERIMENTAL 1
@@ -10,10 +12,12 @@
 #include <glm/vec3.hpp>
 
 #include <cmath>
+#include <vector>
 
 namespace {
 
-constexpr double kTolerance = 1.0e-12;
+constexpr double kTolerance      = 1.0e-12;
+constexpr double kAngleTolerance = 1.0e-10;
 
 void expect_vec_near(glm::dvec3 const& actual,
                      glm::dvec3 const& expected,
@@ -26,8 +30,38 @@ void expect_vec_near(glm::dvec3 const& actual,
 bool same_rotation(glm::dquat const& a,
                    glm::dquat const& b,
                    double            tolerance = kTolerance) {
-    return glm::length(a - b) <= tolerance ||
-           glm::length(a + b) <= tolerance;
+    return glm::length(a - b) <= tolerance || glm::length(a + b) <= tolerance;
+}
+
+struct Basis {
+    glm::dvec3 x;
+    glm::dvec3 y;
+    glm::dvec3 z;
+};
+
+Basis materialize_in_simdata(glm::dvec3 const& direction, double roll) {
+    SolTrace::Data::SingleElement element;
+    element.set_origin(glm::dvec3(0.0));
+    element.set_aim_vector(glm::normalize(direction) * 100.0);
+    element.set_zrot_radians(roll);
+
+    EXPECT_EQ(element.compute_coordinate_rotations(), 0);
+
+    auto const materialized = element.get_local_to_reference();
+
+    return Basis {
+        .x = glm::normalize(materialized * glm::dvec3(1.0, 0.0, 0.0)),
+        .y = glm::normalize(materialized * glm::dvec3(0.0, 1.0, 0.0)),
+        .z = glm::normalize(materialized * glm::dvec3(0.0, 0.0, 1.0)),
+    };
+}
+
+void expect_basis_near(Basis const& actual,
+                       Basis const& expected,
+                       double       tolerance = kAngleTolerance) {
+    expect_vec_near(actual.x, expected.x, tolerance);
+    expect_vec_near(actual.y, expected.y, tolerance);
+    expect_vec_near(actual.z, expected.z, tolerance);
 }
 
 } // namespace
@@ -53,6 +87,99 @@ TEST(DirRollToQuat, AppliesRollAroundDirection) {
     auto q = db::dir_roll_to_quat(direction, roll);
 
     expect_vec_near(q * glm::dvec3(0.0, 0.0, 1.0), direction);
-    expect_vec_near(q * glm::dvec3(0.0, 1.0, 0.0),
-                    glm::dvec3(-1.0, 0.0, 0.0));
+    expect_vec_near(q * glm::dvec3(0.0, 1.0, 0.0), glm::dvec3(-1.0, 0.0, 0.0));
+}
+
+TEST(DirRollToQuat, RoundTripsThroughQuatToDirRollAndSimData) {
+    struct Case {
+        glm::dvec3 direction;
+        double     roll;
+    };
+
+    std::vector<Case> const cases {
+        { glm::normalize(glm::dvec3(0.0, 0.0, 1.0)), 0.0 },
+        { glm::normalize(glm::dvec3(0.0, 0.0, 1.0)), glm::half_pi<double>() },
+        { glm::normalize(glm::dvec3(1.0, 2.0, 3.0)), 0.7 },
+        { glm::normalize(glm::dvec3(-2.0, 5.0, 1.0)), -1.2 },
+        { glm::normalize(glm::dvec3(0.3, -0.7, 0.64)), glm::pi<double>() },
+    };
+
+    for (auto const& item : cases) {
+        SCOPED_TRACE("dir=(" + std::to_string(item.direction.x) + ", " +
+                     std::to_string(item.direction.y) + ", " +
+                     std::to_string(item.direction.z) +
+                     "), roll=" + std::to_string(item.roll));
+
+        auto basis0 = materialize_in_simdata(item.direction, item.roll);
+        auto q0     = glm::quat_cast(glm::dmat3(basis0.x, basis0.y, basis0.z));
+
+        glm::dvec3 decoded_direction;
+        double     decoded_roll = 0.0;
+        db::quat_to_dir_roll(q0, decoded_direction, decoded_roll);
+
+        auto basis1 = materialize_in_simdata(decoded_direction, decoded_roll);
+
+        expect_vec_near(decoded_direction, item.direction, kAngleTolerance);
+        expect_basis_near(basis1, basis0);
+    }
+}
+
+TEST(DirRollToQuat, PreservesPowerTowerSurroundElement10028Roll) {
+    glm::dvec3 const expected_x_axis = glm::normalize(
+        glm::dvec3(0.694036915425, 0.719938293569, -0.00127022849067));
+    glm::dvec3 const expected_y_axis = glm::normalize(
+        glm::dvec3(-0.525964115736, 0.50824458421, 0.681945152912));
+    glm::dvec3 const expected_z_axis = glm::normalize(
+        glm::dvec3(0.491604016446, -0.472627015811, 0.731402211468));
+
+    auto q0 = glm::quat_cast(
+        glm::dmat3(expected_x_axis, expected_y_axis, expected_z_axis));
+
+    glm::dvec3 decoded_direction;
+    double     decoded_roll = 0.0;
+    db::quat_to_dir_roll(q0, decoded_direction, decoded_roll);
+
+    auto basis = materialize_in_simdata(decoded_direction, decoded_roll);
+
+    expect_vec_near(decoded_direction, expected_z_axis, kAngleTolerance);
+    expect_vec_near(basis.x, expected_x_axis, kAngleTolerance);
+    expect_vec_near(basis.y, expected_y_axis, kAngleTolerance);
+    expect_vec_near(basis.z, expected_z_axis, kAngleTolerance);
+}
+
+TEST(DirRollToQuat, MaterializesPowerTowerSurroundElement10028InSimData) {
+    glm::dvec3 const expected_x_axis = glm::normalize(
+        glm::dvec3(0.694036915425, 0.719938293569, -0.00127022849067));
+    glm::dvec3 const expected_y_axis = glm::normalize(
+        glm::dvec3(-0.525964115736, 0.50824458421, 0.681945152912));
+    glm::dvec3 const expected_z_axis = glm::normalize(
+        glm::dvec3(0.491604016446, -0.472627015811, 0.731402211468));
+
+    auto q0 = glm::quat_cast(
+        glm::dmat3(expected_x_axis, expected_y_axis, expected_z_axis));
+
+    glm::dvec3 exported_direction;
+    double     exported_roll = 0.0;
+    db::quat_to_dir_roll(q0, exported_direction, exported_roll);
+
+    glm::dvec3 const origin(-859.977, 573.788, -0.520187);
+
+    SolTrace::Data::SingleElement element;
+    element.set_origin(origin);
+    element.set_aim_vector(origin + exported_direction * 100.0);
+    element.set_zrot_radians(exported_roll);
+
+    ASSERT_EQ(element.compute_coordinate_rotations(), 0);
+
+    auto const materialized = element.get_local_to_reference();
+
+    expect_vec_near(glm::normalize(materialized * glm::dvec3(1.0, 0.0, 0.0)),
+                    expected_x_axis,
+                    kAngleTolerance);
+    expect_vec_near(glm::normalize(materialized * glm::dvec3(0.0, 1.0, 0.0)),
+                    expected_y_axis,
+                    kAngleTolerance);
+    expect_vec_near(glm::normalize(materialized * glm::dvec3(0.0, 0.0, 1.0)),
+                    expected_z_axis,
+                    kAngleTolerance);
 }

--- a/google-tests/unit-tests/gui/database_roundtrip_test.cpp
+++ b/google-tests/unit-tests/gui/database_roundtrip_test.cpp
@@ -1,0 +1,562 @@
+#include "database/database.h"
+
+#include "composite_element.hpp"
+#include "native_runner.hpp"
+#include "simulation_data.hpp"
+#include "simulation_result.hpp"
+#include "simulation_runner.hpp"
+#include "sun.hpp"
+
+#include <gtest/gtest.h>
+
+#include <glm/geometric.hpp>
+#include <glm/mat3x3.hpp>
+#include <glm/vec3.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+namespace SD = SolTrace::Data;
+
+constexpr double kTransformTolerance = 1.0e-7;
+constexpr double kValueTolerance     = 1.0e-12;
+
+struct ElementSnapshot {
+    std::string name;
+    bool        enabled = false;
+
+    glm::dvec3 origin { 0.0 };
+    glm::dvec3 x_axis { 0.0 };
+    glm::dvec3 y_axis { 0.0 };
+    glm::dvec3 z_axis { 0.0 };
+    glm::dvec3 aim_axis { 0.0 };
+
+    std::string aperture_json;
+    std::string surface_json;
+    std::string front_optics_json;
+    std::string back_optics_json;
+};
+
+std::string dump_json(nlohmann::ordered_json const& node) {
+    return node.dump();
+}
+
+std::string dump_aperture(SD::Element const& element) {
+    auto aperture = element.get_aperture();
+    if (!aperture) return "null";
+
+    nlohmann::ordered_json node;
+    aperture->write_json(node);
+    return dump_json(node);
+}
+
+std::string dump_surface(SD::Element const& element) {
+    auto surface = element.get_surface();
+    if (!surface) return "null";
+
+    nlohmann::ordered_json node;
+    surface->write_json(node);
+    return dump_json(node);
+}
+
+std::string dump_optics(SD::OpticalProperties const* optics) {
+    if (!optics) return "null";
+
+    nlohmann::ordered_json node;
+    optics->write_json(node);
+    return dump_json(node);
+}
+
+glm::dvec3 normalized_or_zero(glm::dvec3 const& vector) {
+    auto length = glm::length(vector);
+    if (length == 0.0) return glm::dvec3 { 0.0 };
+    return vector / length;
+}
+
+double vec_error(glm::dvec3 const& actual, glm::dvec3 const& expected) {
+    return glm::length(actual - expected);
+}
+
+std::string vec_to_string(glm::dvec3 const& vector) {
+    std::ostringstream out;
+    out << std::setprecision(12) << "(" << vector.x << ", " << vector.y << ", "
+        << vector.z << ")";
+    return out.str();
+}
+
+std::optional<double> cylinder_radius(SD::Element const& element) {
+    auto cylinder =
+        std::dynamic_pointer_cast<SD::Cylinder const>(element.get_surface());
+    if (!cylinder) return std::nullopt;
+    if (!(cylinder->radius > 0.0) || !std::isfinite(cylinder->radius)) {
+        return std::nullopt;
+    }
+    return cylinder->radius;
+}
+
+ElementSnapshot snapshot_element(SD::Element const& element,
+                                 bool legacy_stinput_cylinder_origin = false) {
+    auto local_to_global = element.get_local_to_global();
+    auto origin          = element.get_origin_global();
+    auto z_axis =
+        normalized_or_zero(local_to_global * glm::dvec3 { 0.0, 0.0, 1.0 });
+
+    if (legacy_stinput_cylinder_origin) {
+        if (auto radius = cylinder_radius(element); radius) {
+            origin += z_axis * *radius;
+        }
+    }
+
+    return ElementSnapshot {
+        .name    = element.get_name(),
+        .enabled = element.is_enabled(),
+        .origin  = origin,
+        .x_axis =
+            normalized_or_zero(local_to_global * glm::dvec3 { 1.0, 0.0, 0.0 }),
+        .y_axis =
+            normalized_or_zero(local_to_global * glm::dvec3 { 0.0, 1.0, 0.0 }),
+        .z_axis = z_axis,
+        .aim_axis =
+            normalized_or_zero(element.get_aim_vector_global() - origin),
+        .aperture_json = dump_aperture(element),
+        .surface_json  = dump_surface(element),
+        .front_optics_json =
+            dump_optics(element.get_front_optical_properties()),
+        .back_optics_json = dump_optics(element.get_back_optical_properties()),
+    };
+}
+
+std::int64_t quantize(double value) {
+    return static_cast<std::int64_t>(std::llround(value * 1.0e6));
+}
+
+auto sort_key(ElementSnapshot const& item) {
+    return std::tuple {
+        quantize(item.origin.x), quantize(item.origin.y),
+        quantize(item.origin.z), item.aperture_json,
+        item.surface_json,       item.name,
+    };
+}
+
+std::vector<ElementSnapshot>
+collect_single_element_snapshots(SD::SimulationData const& data,
+                                 bool legacy_stinput_cylinder_origin = false) {
+    std::vector<ElementSnapshot> snapshots;
+    snapshots.reserve(data.get_number_of_elements());
+
+    for (auto iter = data.get_const_iterator(); !data.is_at_end(iter); ++iter) {
+        auto const& element = *iter->second;
+        if (!element.is_single()) continue;
+
+        snapshots.push_back(
+            snapshot_element(element, legacy_stinput_cylinder_origin));
+    }
+
+    std::sort(
+        snapshots.begin(), snapshots.end(), [](auto const& a, auto const& b) {
+            return sort_key(a) < sort_key(b);
+        });
+
+    return snapshots;
+}
+
+std::string mismatch_diagnostic(ElementSnapshot const& actual,
+                                ElementSnapshot const& expected) {
+    std::ostringstream out;
+    out << std::setprecision(12) << "name actual/expected: " << actual.name
+        << " / " << expected.name
+        << "\norigin error: " << vec_error(actual.origin, expected.origin)
+        << "\n  actual origin:   " << vec_to_string(actual.origin)
+        << "\n  expected origin: " << vec_to_string(expected.origin)
+        << "\naim error: " << vec_error(actual.aim_axis, expected.aim_axis)
+        << "\n  actual aim:      " << vec_to_string(actual.aim_axis)
+        << "\n  expected aim:    " << vec_to_string(expected.aim_axis)
+        << "\nx axis error: " << vec_error(actual.x_axis, expected.x_axis)
+        << "\n  actual x axis:   " << vec_to_string(actual.x_axis)
+        << "\n  expected x axis: " << vec_to_string(expected.x_axis)
+        << "\ny axis error: " << vec_error(actual.y_axis, expected.y_axis)
+        << "\n  actual y axis:   " << vec_to_string(actual.y_axis)
+        << "\n  expected y axis: " << vec_to_string(expected.y_axis)
+        << "\nz axis error: " << vec_error(actual.z_axis, expected.z_axis)
+        << "\n  actual z axis:   " << vec_to_string(actual.z_axis)
+        << "\n  expected z axis: " << vec_to_string(expected.z_axis);
+    return out.str();
+}
+
+std::string max_error_summary(std::vector<ElementSnapshot> const& actual,
+                              std::vector<ElementSnapshot> const& expected) {
+    auto count = std::min(actual.size(), expected.size());
+
+    struct MaxError {
+        double value = 0.0;
+        size_t index = 0;
+    };
+
+    auto update = [](MaxError& max_error, double value, size_t index) {
+        if (value > max_error.value) {
+            max_error.value = value;
+            max_error.index = index;
+        }
+    };
+
+    MaxError origin;
+    MaxError aim;
+    MaxError x_axis;
+    MaxError y_axis;
+    MaxError z_axis;
+
+    for (size_t i = 0; i < count; ++i) {
+        update(origin, vec_error(actual[i].origin, expected[i].origin), i);
+        update(aim, vec_error(actual[i].aim_axis, expected[i].aim_axis), i);
+        update(x_axis, vec_error(actual[i].x_axis, expected[i].x_axis), i);
+        update(y_axis, vec_error(actual[i].y_axis, expected[i].y_axis), i);
+        update(z_axis, vec_error(actual[i].z_axis, expected[i].z_axis), i);
+    }
+
+    std::ostringstream out;
+    out << std::setprecision(12) << "max origin error: " << origin.value
+        << " at " << origin.index << "\nmax aim error: " << aim.value << " at "
+        << aim.index << "\nmax x axis error: " << x_axis.value << " at "
+        << x_axis.index << "\nmax y axis error: " << y_axis.value << " at "
+        << y_axis.index << "\nmax z axis error: " << z_axis.value << " at "
+        << z_axis.index;
+    return out.str();
+}
+
+void expect_vec_near(glm::dvec3 const& actual,
+                     glm::dvec3 const& expected,
+                     double            tolerance = kTransformTolerance) {
+    EXPECT_NEAR(actual.x, expected.x, tolerance);
+    EXPECT_NEAR(actual.y, expected.y, tolerance);
+    EXPECT_NEAR(actual.z, expected.z, tolerance);
+}
+
+void expect_scalar_near_or_both_nan(double actual,
+                                    double expected,
+                                    double tolerance = kValueTolerance) {
+    if (std::isnan(actual) && std::isnan(expected)) return;
+
+    EXPECT_NEAR(actual, expected, tolerance);
+}
+
+void expect_sun_near(SD::RaySource const& actual,
+                     SD::RaySource const& expected) {
+    EXPECT_EQ(actual.get_shape(), expected.get_shape());
+    EXPECT_EQ(actual.get_gen_type(), expected.get_gen_type());
+    expect_vec_near(actual.get_position(), expected.get_position());
+
+    auto& actual_mutable   = const_cast<SD::RaySource&>(actual);
+    auto& expected_mutable = const_cast<SD::RaySource&>(expected);
+
+    expect_scalar_near_or_both_nan(actual_mutable.get_sigma(),
+                                   expected_mutable.get_sigma());
+    expect_scalar_near_or_both_nan(actual_mutable.get_half_width(),
+                                   expected_mutable.get_half_width());
+    expect_scalar_near_or_both_nan(actual_mutable.get_circumsolar_ratio(),
+                                   expected_mutable.get_circumsolar_ratio());
+
+    std::vector<double> actual_angle;
+    std::vector<double> actual_intensity;
+    std::vector<double> expected_angle;
+    std::vector<double> expected_intensity;
+
+    actual_mutable.get_user_data(actual_angle, actual_intensity);
+    expected_mutable.get_user_data(expected_angle, expected_intensity);
+
+    ASSERT_EQ(actual_angle.size(), expected_angle.size());
+    ASSERT_EQ(actual_intensity.size(), expected_intensity.size());
+
+    for (size_t i = 0; i < actual_angle.size(); ++i) {
+        EXPECT_NEAR(actual_angle[i], expected_angle[i], kValueTolerance);
+    }
+
+    for (size_t i = 0; i < actual_intensity.size(); ++i) {
+        EXPECT_NEAR(
+            actual_intensity[i], expected_intensity[i], kValueTolerance);
+    }
+}
+
+void expect_simulation_parameters_equal(SD::SimulationData const& actual,
+                                        SD::SimulationData const& expected) {
+    auto const& actual_params   = actual.get_simulation_parameters();
+    auto const& expected_params = expected.get_simulation_parameters();
+
+    EXPECT_EQ(actual_params.number_of_rays, expected_params.number_of_rays);
+    EXPECT_EQ(actual_params.max_number_of_rays,
+              expected_params.max_number_of_rays);
+    EXPECT_NEAR(
+        actual_params.tolerance, expected_params.tolerance, kValueTolerance);
+    EXPECT_NEAR(
+        actual_params.latitude, expected_params.latitude, kValueTolerance);
+    EXPECT_NEAR(
+        actual_params.longitude, expected_params.longitude, kValueTolerance);
+    EXPECT_EQ(actual_params.seed, expected_params.seed);
+    EXPECT_EQ(actual_params.include_sun_shape_errors,
+              expected_params.include_sun_shape_errors);
+    EXPECT_EQ(actual_params.include_optical_errors,
+              expected_params.include_optical_errors);
+}
+
+void expect_snapshots_near(ElementSnapshot const& actual,
+                           ElementSnapshot const& expected,
+                           size_t                 index) {
+    SCOPED_TRACE(mismatch_diagnostic(actual, expected));
+
+    {
+        SCOPED_TRACE("single element snapshot " + std::to_string(index));
+
+        EXPECT_EQ(actual.name, expected.name);
+        EXPECT_EQ(actual.enabled, expected.enabled);
+        EXPECT_EQ(actual.aperture_json, expected.aperture_json);
+        EXPECT_EQ(actual.surface_json, expected.surface_json);
+        EXPECT_EQ(actual.front_optics_json, expected.front_optics_json);
+        EXPECT_EQ(actual.back_optics_json, expected.back_optics_json);
+    }
+
+    {
+        SCOPED_TRACE("single element snapshot origin " + std::to_string(index));
+        expect_vec_near(actual.origin, expected.origin);
+    }
+
+    {
+        SCOPED_TRACE("single element snapshot axis " + std::to_string(index));
+
+        expect_vec_near(actual.aim_axis, expected.aim_axis);
+        expect_vec_near(actual.x_axis, expected.x_axis);
+        expect_vec_near(actual.y_axis, expected.y_axis);
+        expect_vec_near(actual.z_axis, expected.z_axis);
+    }
+}
+
+std::filesystem::path power_tower_surround_path() {
+    return std::filesystem::path(SOLTRACE_REPO_ROOT) /
+           "gui/assets/examples/Power-tower-surround.stinput";
+}
+
+void configure_tiny_deterministic_run(SD::SimulationData& data) {
+    data.set_seed(12345);
+    data.set_number_of_rays(5);
+    data.set_max_rays_traced(500);
+
+    auto& params                    = data.get_simulation_parameters();
+    params.include_sun_shape_errors = false;
+    params.include_optical_errors   = false;
+}
+
+std::unique_ptr<SolTrace::Result::SimulationResult>
+run_native_trace(SD::SimulationData& data, bool disable_stages = false) {
+    SolTrace::NativeRunner::NativeRunner runner;
+    runner.set_number_of_threads(1);
+    if (disable_stages) { runner.disable_stages(); }
+
+    EXPECT_EQ(runner.initialize(), SolTrace::Runner::RunnerStatus::SUCCESS);
+    EXPECT_EQ(runner.setup_simulation(&data),
+              SolTrace::Runner::RunnerStatus::SUCCESS);
+    EXPECT_EQ(runner.run_simulation(), SolTrace::Runner::RunnerStatus::SUCCESS);
+
+    auto result = std::make_unique<SolTrace::Result::SimulationResult>();
+    EXPECT_EQ(runner.report_simulation(result.get(), 0),
+              SolTrace::Runner::RunnerStatus::SUCCESS);
+
+    return result;
+}
+
+std::vector<SolTrace::Result::ray_record_ptr>
+collect_ray_records(SolTrace::Result::SimulationResult const& result) {
+    std::vector<SolTrace::Result::ray_record_ptr> records;
+    records.reserve(result.get_number_of_records());
+
+    for (auto iter = result.get_ray_record_iterator(); !result.is_at_end(iter);
+         ++iter) {
+        records.push_back(*iter);
+    }
+
+    return records;
+}
+
+std::map<SolTrace::Result::ray_id, SolTrace::Result::ray_record_ptr>
+collect_ray_records_by_id(SolTrace::Result::SimulationResult const& result) {
+    std::map<SolTrace::Result::ray_id, SolTrace::Result::ray_record_ptr>
+        records;
+
+    for (auto iter = result.get_ray_record_iterator(); !result.is_at_end(iter);
+         ++iter) {
+        records.emplace((*iter)->id, *iter);
+    }
+
+    return records;
+}
+
+void expect_interaction_near(
+    SolTrace::Result::InteractionRecord const& actual,
+    SolTrace::Result::InteractionRecord const& expected,
+    SolTrace::Result::ray_id                   ray_id,
+    size_t                                     event_index) {
+    SCOPED_TRACE("ray id " + std::to_string(ray_id) + ", event " +
+                 std::to_string(event_index));
+
+    EXPECT_EQ(actual.event, expected.event);
+    expect_vec_near(actual.location, expected.location, 1.0e-6);
+    expect_vec_near(actual.direction, expected.direction, 1.0e-9);
+}
+
+void expect_ray_record_near(SolTrace::Result::RayRecord const& actual,
+                            SolTrace::Result::RayRecord const& expected,
+                            SolTrace::Result::ray_id           ray_id) {
+    SCOPED_TRACE("ray record id " + std::to_string(ray_id));
+
+    EXPECT_EQ(actual.id, expected.id);
+    ASSERT_EQ(actual.interactions.size(), expected.interactions.size());
+
+    for (size_t i = 0; i < expected.interactions.size(); ++i) {
+        expect_interaction_near(
+            *actual.interactions[i], *expected.interactions[i], ray_id, i);
+    }
+}
+
+std::string sun_box_summary(SolTrace::Result::SimulationResult& actual,
+                            SolTrace::Result::SimulationResult& expected) {
+    double actual_width    = 0.0;
+    double actual_height   = 0.0;
+    double expected_width  = 0.0;
+    double expected_height = 0.0;
+
+    actual.get_sun_dimensions(actual_width, actual_height);
+    expected.get_sun_dimensions(expected_width, expected_height);
+
+    std::ostringstream out;
+    out << std::setprecision(12) << "actual sun box: width=" << actual_width
+        << ", height=" << actual_height << ", area=" << actual.get_sun_A_box()
+        << "\nexpected sun box: width=" << expected_width
+        << ", height=" << expected_height
+        << ", area=" << expected.get_sun_A_box();
+    return out.str();
+}
+
+void expect_sun_box_near(SolTrace::Result::SimulationResult& actual,
+                         SolTrace::Result::SimulationResult& expected,
+                         bool compare_sun_ray_count = true) {
+    SCOPED_TRACE(sun_box_summary(actual, expected));
+
+    if (compare_sun_ray_count) {
+        EXPECT_EQ(actual.get_sun_ray_count(), expected.get_sun_ray_count());
+    }
+
+    double actual_width    = 0.0;
+    double actual_height   = 0.0;
+    double expected_width  = 0.0;
+    double expected_height = 0.0;
+
+    actual.get_sun_dimensions(actual_width, actual_height);
+    expected.get_sun_dimensions(expected_width, expected_height);
+
+    EXPECT_NEAR(actual_width, expected_width, 1.0e-7);
+    EXPECT_NEAR(actual_height, expected_height, 1.0e-7);
+    EXPECT_NEAR(actual.get_sun_A_box(), expected.get_sun_A_box(), 1.0e-4);
+}
+
+} // namespace
+
+TEST(DatabaseRoundTrip, PowerTowerSurroundExportsEquivalentGlobalSimData) {
+    SD::SimulationData original;
+    ASSERT_TRUE(
+        original.import_from_file(power_tower_surround_path().string()));
+
+    db::Database database("round-trip");
+    database.import(original, true /* legacy_stinput_cylinder_origins */);
+
+    auto exported = database.export_to_simdata();
+    ASSERT_NE(exported, nullptr);
+    ASSERT_NE(exported->data, nullptr);
+
+    expect_simulation_parameters_equal(*exported->data, original);
+
+    ASSERT_EQ(exported->data->get_number_of_ray_sources(),
+              original.get_number_of_ray_sources());
+    expect_sun_near(*exported->data->get_ray_source(),
+                    *original.get_ray_source());
+
+    auto actual_snapshots   = collect_single_element_snapshots(*exported->data);
+    auto expected_snapshots = collect_single_element_snapshots(
+        original, true /* legacy_stinput_cylinder_origin */);
+
+    ASSERT_EQ(actual_snapshots.size(), expected_snapshots.size());
+
+    SCOPED_TRACE(max_error_summary(actual_snapshots, expected_snapshots));
+
+    for (size_t i = 0; i < expected_snapshots.size(); ++i) {
+        expect_snapshots_near(actual_snapshots[i], expected_snapshots[i], i);
+    }
+}
+
+TEST(DatabaseRoundTrip, PowerTowerSurroundNativeTraceMatchesOriginalSimData) {
+    SD::SimulationData original;
+    ASSERT_TRUE(
+        original.import_from_file(power_tower_surround_path().string()));
+    configure_tiny_deterministic_run(original);
+
+    SD::SimulationData source_for_database;
+    ASSERT_TRUE(source_for_database.import_from_file(
+        power_tower_surround_path().string()));
+
+    db::Database database("round-trip-trace");
+    database.import(source_for_database,
+                    true /* legacy_stinput_cylinder_origins */);
+
+    auto exported = database.export_to_simdata();
+    ASSERT_NE(exported, nullptr);
+    ASSERT_NE(exported->data, nullptr);
+
+    configure_tiny_deterministic_run(*exported->data);
+
+    SD::SimulationData source_for_expected;
+    ASSERT_TRUE(source_for_expected.import_from_file(
+        power_tower_surround_path().string()));
+
+    db::Database expected_database("round-trip-trace-expected");
+    expected_database.import(source_for_expected,
+                             true /* legacy_stinput_cylinder_origins */);
+
+    auto expected_exported = expected_database.export_to_simdata();
+    ASSERT_NE(expected_exported, nullptr);
+    ASSERT_NE(expected_exported->data, nullptr);
+    configure_tiny_deterministic_run(*expected_exported->data);
+
+    auto staged_result   = run_native_trace(original);
+    auto expected_result = run_native_trace(*expected_exported->data);
+    auto actual_result   = run_native_trace(*exported->data);
+
+    expect_sun_box_near(
+        *actual_result, *staged_result, false /* compare_sun_ray_count */);
+    expect_sun_box_near(*actual_result, *expected_result);
+
+    auto expected_records = collect_ray_records_by_id(*expected_result);
+    auto actual_records   = collect_ray_records_by_id(*actual_result);
+
+    ASSERT_FALSE(expected_records.empty());
+    ASSERT_EQ(actual_records.size(), expected_records.size());
+
+    size_t compared = 0;
+    for (auto const& [ray_id, expected_record] : expected_records) {
+        auto actual_iter = actual_records.find(ray_id);
+        ASSERT_NE(actual_iter, actual_records.end())
+            << "missing actual ray id " << ray_id;
+
+        expect_ray_record_near(*actual_iter->second, *expected_record, ray_id);
+
+        compared++;
+        if (compared >= 5) break;
+    }
+}

--- a/gui/CMakeLists.txt
+++ b/gui/CMakeLists.txt
@@ -242,6 +242,13 @@ install(TARGETS SolTrace
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+install(DIRECTORY
+    "${CMAKE_CURRENT_SOURCE_DIR}/assets/examples"
+    "${CMAKE_CURRENT_SOURCE_DIR}/assets/scripts"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/SolTrace/assets"
+    PATTERN ".DS_Store" EXCLUDE
+)
+
 qt_generate_deploy_qml_app_script(
     TARGET SolTrace
     OUTPUT_SCRIPT deploy_script

--- a/gui/src/analysis/baked_flux_map.h
+++ b/gui/src/analysis/baked_flux_map.h
@@ -3,13 +3,32 @@
 #include "utilities/grid2d.h"
 
 #include <QImage>
+#include <QMetaType>
+#include <QObject>
 #include <QtGlobal>
 #include <QVector3D>
+#include <qqmlintegration.h>
 
 namespace analysis {
 
 /// Summary statistics computed with the baked flux map.
 struct BakedFluxMapStats {
+    Q_GADGET
+    QML_VALUE_TYPE(baked_flux_map_stats);
+    Q_PROPERTY(quint64 source_ray_count MEMBER source_ray_count)
+    Q_PROPERTY(quint64 plotted_ray_count MEMBER plotted_ray_count)
+    Q_PROPERTY(double power_per_ray MEMBER power_per_ray)
+    Q_PROPERTY(double plotted_power MEMBER plotted_power)
+    Q_PROPERTY(double peak_flux MEMBER peak_flux)
+    Q_PROPERTY(double min_flux MEMBER min_flux)
+    Q_PROPERTY(double average_flux MEMBER average_flux)
+    Q_PROPERTY(double sigma_flux MEMBER sigma_flux)
+    Q_PROPERTY(double uniformity MEMBER uniformity)
+    Q_PROPERTY(double peak_flux_uncertainty MEMBER peak_flux_uncertainty)
+    Q_PROPERTY(double average_flux_uncertainty MEMBER average_flux_uncertainty)
+    Q_PROPERTY(QVector3D centroid MEMBER centroid)
+
+public:
     /// Total rays in the simulation result used for this map.
     quint64 source_ray_count = 0;
 
@@ -35,6 +54,8 @@ struct BakedFluxMapStats {
 
     /// Average world-space location of plotted interactions.
     QVector3D centroid;
+
+    bool operator==(BakedFluxMapStats const&) const = default;
 };
 
 /// A computed flux map
@@ -55,3 +76,5 @@ struct BakedFluxMap {
 using BakedFluxMapPtr = std::shared_ptr<BakedFluxMap const>;
 
 } // namespace analysis
+
+Q_DECLARE_METATYPE(analysis::BakedFluxMapStats)

--- a/gui/src/analysis/baked_flux_map.h
+++ b/gui/src/analysis/baked_flux_map.h
@@ -3,8 +3,39 @@
 #include "utilities/grid2d.h"
 
 #include <QImage>
+#include <QtGlobal>
+#include <QVector3D>
 
 namespace analysis {
+
+/// Summary statistics computed with the baked flux map.
+struct BakedFluxMapStats {
+    /// Total rays in the simulation result used for this map.
+    quint64 source_ray_count = 0;
+
+    /// Number of plotted ray/surface interactions that contributed to this map.
+    quint64 plotted_ray_count = 0;
+
+    /// Current normalized energy per plotted ray interaction.
+    double power_per_ray = 1.0;
+
+    /// Integrated normalized power represented by plotted interactions.
+    double plotted_power = 0.0;
+
+    /// Flux statistics over the rasterized map values.
+    double peak_flux    = 0.0;
+    double min_flux     = 0.0;
+    double average_flux = 0.0;
+    double sigma_flux   = 0.0;
+    double uniformity   = 0.0;
+
+    /// Monte Carlo uncertainty estimates in percent where counts are known.
+    double peak_flux_uncertainty    = 0.0;
+    double average_flux_uncertainty = 0.0;
+
+    /// Average world-space location of plotted interactions.
+    QVector3D centroid;
+};
 
 /// A computed flux map
 struct BakedFluxMap {
@@ -16,6 +47,9 @@ struct BakedFluxMap {
 
     /// A generated image showing UV points of intersecting rays
     QImage point_map;
+
+    /// Summary statistics for the generated map.
+    BakedFluxMapStats stats;
 };
 
 using BakedFluxMapPtr = std::shared_ptr<BakedFluxMap const>;

--- a/gui/src/analysis/flux_map.cpp
+++ b/gui/src/analysis/flux_map.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <optional>
 
 #define GLM_ENABLE_EXPERIMENTAL 1
@@ -412,6 +413,77 @@ static bool dump_interaction_points_csv(std::vector<glm::vec3> const& points,
     return true;
 }
 
+static BakedFluxMapStats
+compute_flux_map_stats(Grid2D<float> const&                    raster,
+                       std::vector<TriangleFluxBin> const&     triangles,
+                       std::vector<glm::vec3> const&           interaction_points,
+                       std::size_t                             source_ray_count,
+                       double                                  power_per_ray) {
+    BakedFluxMapStats stats;
+    stats.source_ray_count  = static_cast<quint64>(source_ray_count);
+    stats.plotted_ray_count = static_cast<quint64>(interaction_points.size());
+    stats.power_per_ray     = power_per_ray;
+    stats.plotted_power     = stats.plotted_ray_count * stats.power_per_ray;
+
+    if (!interaction_points.empty()) {
+        glm::dvec3 centroid(0.0);
+        for (auto const& point : interaction_points) {
+            centroid += glm::dvec3(point);
+        }
+        centroid /= static_cast<double>(interaction_points.size());
+        stats.centroid = QVector3D(centroid.x, centroid.y, centroid.z);
+    }
+
+    if (raster.size() == 0) return stats;
+
+    double sum       = 0.0;
+    double sum_sq    = 0.0;
+    double min_flux  = std::numeric_limits<double>::max();
+    double peak_flux = 0.0;
+
+    for (unsigned i = 0; i < raster.size(); ++i) {
+        const double value = raster[i];
+        sum += value;
+        sum_sq += value * value;
+        min_flux  = std::min(min_flux, value);
+        peak_flux = std::max(peak_flux, value);
+    }
+
+    const double bin_count = raster.size();
+    stats.peak_flux        = peak_flux;
+    stats.min_flux         = min_flux == std::numeric_limits<double>::max()
+                                 ? 0.0
+                                 : min_flux;
+    stats.average_flux     = sum / bin_count;
+
+    const double variance =
+        (bin_count * sum_sq - sum * sum) / (bin_count * bin_count);
+    stats.sigma_flux = std::sqrt(std::max(0.0, variance));
+    stats.uniformity = stats.average_flux > 0.0
+                           ? stats.sigma_flux / stats.average_flux
+                           : 0.0;
+
+    std::size_t peak_hit_count = 0;
+    double      peak_triangle_flux = 0.0;
+    for (auto const& triangle : triangles) {
+        if (triangle.flux > peak_triangle_flux) {
+            peak_triangle_flux = triangle.flux;
+            peak_hit_count     = triangle.hit_count;
+        }
+    }
+
+    if (peak_hit_count > 0) {
+        stats.peak_flux_uncertainty =
+            100.0 / std::sqrt(static_cast<double>(peak_hit_count));
+    }
+    if (source_ray_count > 0) {
+        stats.average_flux_uncertainty =
+            100.0 / std::sqrt(static_cast<double>(source_ray_count));
+    }
+
+    return stats;
+}
+
 /// Main fluxmap compute function
 void execute_map_generation_for(QPromise<BakedFluxMapPtr>& promise,
                                 FluxMapBakeOptions         opts,
@@ -457,6 +529,7 @@ void execute_map_generation_for(QPromise<BakedFluxMapPtr>& promise,
 
     qDebug() << Q_FUNC_INFO << "ready triangle bins";
 
+    constexpr double       power_per_ray    = 1.0;
     float                  total_ray_impact = 0.0f;
     std::vector<glm::vec2> interaction_uvs;
     std::vector<glm::vec3> interaction_points;
@@ -507,8 +580,7 @@ void execute_map_generation_for(QPromise<BakedFluxMapPtr>& promise,
 
             auto& triangle = triangles[projection->triangle_index];
 
-            float hit_energy = 1.0f; // replace with actual interaction/ray
-                                     // power when available
+            float hit_energy = static_cast<float>(power_per_ray);
             triangle.hit_count += 1;
             triangle.accumulated_energy += hit_energy;
             total_ray_impact += hit_energy;
@@ -551,6 +623,11 @@ void execute_map_generation_for(QPromise<BakedFluxMapPtr>& promise,
 
     auto points_img =
         make_points_debug_image(interaction_uvs, img.size(), mesh);
+    auto stats = compute_flux_map_stats(raster,
+                                        triangles,
+                                        interaction_points,
+                                        results->records.size(),
+                                        power_per_ray);
 
     qDebug() << Q_FUNC_INFO << "complete";
 
@@ -566,6 +643,7 @@ void execute_map_generation_for(QPromise<BakedFluxMapPtr>& promise,
         .counts    = std::move(raster),
         .bin_map   = img,
         .point_map = points_img,
+        .stats     = stats,
     }));
 }
 

--- a/gui/src/app_data.cpp
+++ b/gui/src/app_data.cpp
@@ -89,9 +89,9 @@ void AppData::load_session() {
     // Sun Shape
     m_sun->shape()->set_shape(
         static_cast<SunShape::Shape>(s.value("shape", 0).toDouble()));
-    m_sun->shape()->set_sigma(s.value("sigma", 1.551).toDouble());
-    m_sun->shape()->set_half_width(s.value("half_width", 2.023).toDouble());
-    m_sun->shape()->set_csr(s.value("buie_csr", 0.596).toDouble());
+    m_sun->shape()->set_sigma(s.value("sigma", 4.65).toDouble());
+    m_sun->shape()->set_half_width(s.value("half_width", 4.65).toDouble());
+    m_sun->shape()->set_csr(s.value("buie_csr", 0.1).toDouble());
 
     auto* cdist = m_sun->shape()->custom_distribution();
     if (s.contains("custom_shape"))

--- a/gui/src/database/apertureeditor.cpp
+++ b/gui/src/database/apertureeditor.cpp
@@ -207,7 +207,7 @@ ApertureParameterModel::valid_apertures_for_surf(SD::SurfaceType st) {
     switch (st) {
     case SolTrace::Data::CYLINDER: {
         static constexpr std::array<SD::ApertureType, 1> valid = {
-            SolTrace::Data::SINGLE_AXIS_CURVATURE_SECTION,
+            SolTrace::Data::RECTANGLE,
         };
         return valid;
     }

--- a/gui/src/database/conversion.cpp
+++ b/gui/src/database/conversion.cpp
@@ -19,10 +19,6 @@ static inline double wrap_pi(double a) {
     return a - PI;
 }
 
-static inline double angle_diff(double a, double b) {
-    return std::abs(wrap_pi(a - b));
-}
-
 static inline glm::dquat align_unit_vector(glm::dvec3 const& fromUnit,
                                            glm::dvec3 const& toUnit) {
     double d = glm::dot(fromUnit, toUnit);
@@ -55,40 +51,6 @@ glm::dquat dir_roll_to_quat(glm::dvec3 const& directionWorld,
     return glm::normalize(qRoll * qAlign);
 }
 
-static inline glm::dquat twist_around_axis(glm::dquat const& q,
-                                           glm::dvec3 const& axisUnit) {
-    glm::dvec3 v(q.x, q.y, q.z);
-    auto       proj = axisUnit * glm::dot(v, axisUnit);
-
-    glm::dquat twist(q.w, proj.x, proj.y, proj.z);
-    double     n = glm::length(twist);
-    if (n < 1e-8) return glm::identity<glm::dquat>();
-
-    return glm::normalize(twist);
-}
-
-static inline double twist_angle_radians(glm::dquat const& twist,
-                                         glm::dvec3 const& axisUnit) {
-    auto t = glm::normalize(twist);
-
-    glm::dvec3 v(t.x, t.y, t.z);
-    double     vlen = glm::length(v);
-    double     w    = t.w;
-
-    double angle = 2.0 * std::atan2(vlen, w); // [0, 2pi)
-    double s     = glm::dot(v, axisUnit);
-    if (s < 0.0) angle = -angle;
-
-    return wrap_pi(angle);
-}
-
-static inline bool approx_equal_quat(glm::dquat const& a,
-                                     glm::dquat const& b,
-                                     double            eps = 1e-5f) {
-    // q and -q represent the same rotation
-    return glm::length(a - b) <= eps || glm::length(a + b) <= eps;
-}
-
 void quat_to_dir_roll(glm::dquat const& qIn,
                       glm::dvec3&       outDirectionWorld,
                       double&           outZRollRadians) {
@@ -107,8 +69,19 @@ void quat_to_dir_roll(glm::dquat const& qIn,
     dir /= len;
     outDirectionWorld = dir;
 
-    auto twist      = twist_around_axis(q, dir);
-    outZRollRadians = twist_angle_radians(twist, dir);
+    // SimulationData does not treat zrot as an arbitrary quaternion twist
+    // around the aim vector. It stores zrot as gamma in the Spencer/Murty
+    // Euler convention used by CalculateTransformMatrices().
+    auto local_to_reference = glm::mat3_cast(q);
+    auto reference_to_local = glm::transpose(local_to_reference);
+
+    // CalculateTransformMatrices fills:
+    // RRefToLoc[1][0] = -cos(beta) * sin(gamma)
+    // RRefToLoc[1][1] =  cos(beta) * cos(gamma)
+    // GLM indexes matrices as m[column][row].
+    outZRollRadians =
+        wrap_pi(std::atan2(-reference_to_local[1][0],
+                           reference_to_local[1][1]));
 }
 
 

--- a/gui/src/database/database.cpp
+++ b/gui/src/database/database.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <unordered_map>
 
 #define GLM_ENABLE_EXPERIMENTAL 1
@@ -611,7 +612,45 @@ struct StageComponent {
     TransformComponent this_in_stage;
 };
 
-void Database::import(SD::SimulationData& data) {
+static std::optional<double> cylinder_radius(SD::surface_ptr const& surface) {
+    auto cylinder = std::dynamic_pointer_cast<SD::Cylinder const>(surface);
+    if (!cylinder) return std::nullopt;
+    if (!(cylinder->radius > 0.0) || !std::isfinite(cylinder->radius)) {
+        return std::nullopt;
+    }
+    return cylinder->radius;
+}
+
+static void apply_legacy_stinput_cylinder_origin_shift(
+    entt::registry& registry) {
+
+    auto view =
+        registry.view<ElementComponent, GeometryGroupMemberComponent const>();
+
+    for (auto [entity, geometry_membership] : view.each()) {
+
+        auto const* geometry =
+            registry.try_get<GeometryComponent>(geometry_membership.group);
+        if (!geometry) continue;
+
+        auto radius = cylinder_radius(geometry->surface);
+        if (!radius) continue;
+
+        // Legacy .stinput files use the historical SolTrace cylinder
+        // convention: the element origin is at the cylinder vertex and the
+        // cylinder center is one radius along local +Z. Current native runner
+        // code interprets cylinder origins as centered, so burn that
+        // compatibility shift into the GUI database only while importing
+        // legacy files. Do not apply this to JSON/native database loads.
+        registry.patch<TransformComponent>(entity, [radius](auto& item) {
+            item.position +=
+                item.rotation * glm::dvec3 { 0.0, 0.0, *radius };
+        });
+    }
+}
+
+void Database::import(SD::SimulationData& data,
+                      bool legacy_stinput_cylinder_origins) {
 
     // Assuming we are not re-using registries, which we are not for the moment
     auto imported_tag = create_tag("imported");
@@ -748,6 +787,10 @@ void Database::import(SD::SimulationData& data) {
         }
 
         m_registry.clear<StageComponent>();
+    }
+
+    if (legacy_stinput_cylinder_origins) {
+        apply_legacy_stinput_cylinder_origin_shift(m_registry);
     }
 
     ray_source_resource.set(RaySourceResource {

--- a/gui/src/database/database.h
+++ b/gui/src/database/database.h
@@ -76,7 +76,11 @@ public:
     /// the database constructor. We have this split here so that we can
     /// allocate a database on one thread and fill it in another.
     /// Thus: DO NOT DO QObject THINGS IN THIS FUNCTION, only fill the reg.
-    void import(SD::SimulationData&);
+    /// If importing a legacy .stinput file, shift cylindrical element origins
+    /// from the old vertex-based convention to the current centered-cylinder
+    /// convention used by the native runner.
+    void import(SD::SimulationData&,
+                bool legacy_stinput_cylinder_origins = false);
 
     /// Convert a database back into a Soltrace dataset
     std::shared_ptr<DatabaseExport> export_to_simdata();

--- a/gui/src/database/fluxmapworldmodel.cpp
+++ b/gui/src/database/fluxmapworldmodel.cpp
@@ -281,6 +281,7 @@ void FluxMapWorldModel::on_ready(Entity                    e,
         .flux_position     = position,
         .flux_rotation     = rotation,
         .flux_geometry     = geom,
+        .flux_stats        = img->stats,
     });
 }
 

--- a/gui/src/database/fluxmapworldmodel.h
+++ b/gui/src/database/fluxmapworldmodel.h
@@ -93,6 +93,7 @@ struct FluxMappedItem {
     QVector3D                            flux_position;
     QQuaternion                          flux_rotation;
     std::shared_ptr<SurfaceGeometry>     flux_geometry;
+    analysis::BakedFluxMapStats          flux_stats;
 
     RECORD_META(FluxMappedItem,
                 SM_EXPOSE_RO(flux_entity),
@@ -100,7 +101,8 @@ struct FluxMappedItem {
                 SM_EXPOSE_RO(flux_image_path),
                 SM_EXPOSE_RO(flux_position),
                 SM_EXPOSE_RO(flux_rotation),
-                SM_EXPOSE_RO(flux_geometry));
+                SM_EXPOSE_RO(flux_geometry),
+                SM_EXPOSE_RO(flux_stats));
 };
 
 class FluxMapWorldModel : public StructModelAdapter<FluxMappedItem> {

--- a/gui/src/database/geometryeditor.cpp
+++ b/gui/src/database/geometryeditor.cpp
@@ -255,6 +255,37 @@ void GeometryEditor::recompute_geometry_errors() {
                 .arg(aperture_name, surface_name));
     }
 
+    if (params->surface->my_type == SD::CYLINDER &&
+        params->aperture->my_type == SD::RECTANGLE) {
+
+        auto const* cylinder =
+            dynamic_cast<SD::Cylinder const*>(params->surface.get());
+        auto const* rect =
+            dynamic_cast<SD::Rectangle const*>(params->aperture.get());
+
+        if (cylinder && rect) {
+            auto close = [](double a, double b) {
+                return std::abs(a - b) <= 1.0e-8;
+            };
+
+            const double diameter = 2.0 * cylinder->radius;
+
+            if (cylinder->radius <= 0.0) {
+                errors.push_back("Cylinder radius must be positive.");
+            }
+
+            if (!close(rect->x_length(), diameter)) {
+                errors.push_back(
+                    "Cylinder rectangle width must equal the cylinder diameter.");
+            }
+
+            if (!close(rect->x_coord(), -cylinder->radius)) {
+                errors.push_back(
+                    "Cylinder rectangle X origin must be the negative radius.");
+            }
+        }
+    }
+
     m_geometry_error_model->setStringList(errors);
 }
 

--- a/gui/src/database/surface.cpp
+++ b/gui/src/database/surface.cpp
@@ -725,8 +725,8 @@ generate_cylinder_surface(SD::surface_ptr const&          surface,
             double u      = static_cast<double>(ia) / angular_steps;
             double theta  = u * 2.0 * PI;
             double x      = radius * std::cos(theta);
-            double z      = radius + radius * std::sin(theta);
-            auto   normal = glm::normalize(glm::vec3(x, 0.0, z - radius));
+            double z      = radius * std::sin(theta);
+            auto   normal = glm::normalize(glm::vec3(x, 0.0, z));
 
             mesh.vertex.push_back(make_vertex(x, y, z, normal, u, v));
         }
@@ -757,8 +757,8 @@ generate_cylinder_surface(SD::surface_ptr const&          surface,
             double u      = static_cast<double>(ia) / angular_steps;
             double theta  = u * 2.0 * PI;
             double x      = inner_radius * std::cos(theta);
-            double z      = radius + inner_radius * std::sin(theta);
-            auto   normal = -glm::normalize(glm::vec3(x, 0.0, z - radius));
+            double z      = inner_radius * std::sin(theta);
+            auto   normal = -glm::normalize(glm::vec3(x, 0.0, z));
 
             mesh.vertex.push_back(make_vertex(x, y, z, normal, u, v));
         }

--- a/gui/src/job_control/job_run_thread.cpp
+++ b/gui/src/job_control/job_run_thread.cpp
@@ -104,6 +104,7 @@ void execute_thread_runner(QPromise<SimResult>&      promise,
                 current_runner.get());
             ptr) {
             ptr->set_number_of_threads(thread_count);
+            ptr->disable_stages();
         }
 
 

--- a/gui/src/modules/database_module.cpp
+++ b/gui/src/modules/database_module.cpp
@@ -28,6 +28,10 @@ load_file(QPromise<LoadResult>& result, QString fname, db::Database* new_db) {
         result.setProgressValueAndText(0, "Reading file...");
 
         auto file = QFileInfo(fname);
+        auto suffix = file.suffix().toLower();
+        bool legacy_stinput_cylinder_origins =
+            suffix == QStringLiteral("stinput") ||
+            suffix == QStringLiteral("stimport");
 
         if (!(file.isFile() && file.isReadable())) {
             result.emplaceResult(LoadFileFailed(
@@ -54,7 +58,7 @@ load_file(QPromise<LoadResult>& result, QString fname, db::Database* new_db) {
         stage = "importing content";
         result.setProgressValueAndText(50, "Importing content...");
 
-        destination->import(*new_data);
+        destination->import(*new_data, legacy_stinput_cylinder_origins);
 
         stage = "finalizing";
         result.setProgressValueAndText(100, "Done");

--- a/gui/src/modules/flux_module.cpp
+++ b/gui/src/modules/flux_module.cpp
@@ -29,15 +29,25 @@ FluxModule::FluxModule(QQmlEngine* engine, QObject* parent)
             &db::FluxMapWorldModel::on_ready);
 
     connect(m_pending_flux_maps,
+            &db::PendingFluxMapModel::ready,
+            this,
+            &FluxModule::flux_map_ready);
+
+    connect(m_pending_flux_maps,
             &db::PendingFluxMapModel::cleared,
             m_flux_map_world_model,
             &db::FluxMapWorldModel::on_reset);
+
+    connect(m_pending_flux_maps, &db::PendingFluxMapModel::cleared, this, [this] {
+        set_current_flux_stats({});
+    });
 }
 
 void FluxModule::set_results(db::SimulationResultPtr p) {
     m_results = p;
     set_current_entity({});
     set_current_entity_name(QString());
+    set_current_flux_stats({});
 
     if (!p) return;
 
@@ -67,10 +77,32 @@ void FluxModule::select_entity(db::Entity entity) {
 
     if (!m_results || !m_results->database || !entity.is_valid()) {
         set_current_entity_name(QString());
+        set_current_flux_stats({});
         return;
     }
 
     set_current_entity_name(m_results->database->name_of(entity));
+    refresh_current_flux_stats();
+}
+
+void FluxModule::refresh_current_flux_stats() {
+    for (auto const& item : m_flux_map_world_model->vector()) {
+        if (item.flux_entity == current_entity()) {
+            set_current_flux_stats(item.flux_stats);
+            return;
+        }
+    }
+
+    set_current_flux_stats({});
+}
+
+void FluxModule::flux_map_ready(db::Entity              entity,
+                                analysis::BakedFluxMapPtr image,
+                                db::Database const*) {
+    if (entity != current_entity()) return;
+
+    set_current_flux_stats(image ? image->stats
+                                 : analysis::BakedFluxMapStats {});
 }
 
 void FluxModule::start_generate() {

--- a/gui/src/modules/flux_module.h
+++ b/gui/src/modules/flux_module.h
@@ -36,11 +36,17 @@ class FluxModule : public QObject {
 
     Q_WRITABLE_PROPERTY(db::Entity, current_entity, {});
     Q_READONLY_PROPERTY(QString, current_entity_name);
+    Q_READONLY_PROPERTY(analysis::BakedFluxMapStats, current_flux_stats);
 
     // Hack
     Q_WRITABLE_PROPERTY(QString, current_image, {});
 
+private:
+    void refresh_current_flux_stats();
+
 private slots:
+    void flux_map_ready(db::Entity, analysis::BakedFluxMapPtr, db::Database const*);
+
     void flux_vol_ready(QUuid const&, analysis::SparseGrid3D<float>);
     void flux_vol_failed(QUuid const&, QString);
 

--- a/gui/src/modules/sun_module.cpp
+++ b/gui/src/modules/sun_module.cpp
@@ -188,7 +188,9 @@ QString SunModule::write_position_to_database() {
     QScopedValueRollback<bool> guard(m_writing_to_database, true);
 
     try {
-        m_current_database->ray_source_resource.patch([this](auto& resource) {
+        m_current_database->ray_source_resource.patch([this](
+                                                          db::RaySourceResource&
+                                                              resource) {
             const bool created = !resource.source;
             if (created) { resource.source = SD::make_ray_source<SD::Sun>(); }
 
@@ -204,6 +206,8 @@ QString SunModule::write_position_to_database() {
 
             resource.source->set_position(
                 m_position->x(), m_position->y(), m_position->z());
+
+            resource.source->set_gen_type(Data::GenType::RANDOM);
         });
     } catch (std::exception const& e) {
         qWarning() << "Unable to update sun position:" << e.what();

--- a/gui/src/modules/sun_module.h
+++ b/gui/src/modules/sun_module.h
@@ -77,7 +77,7 @@ public:
     Q_WRITABLE_PROPERTY(Shape, shape, Shape::Gaussian)
 
     // Gaussian
-    Q_WRITABLE_PROPERTY(double, sigma, 5.18)
+    Q_WRITABLE_PROPERTY(double, sigma, 4.65)
 
     // Pillbox
     Q_WRITABLE_PROPERTY(double, half_width, 4.65)

--- a/gui/src/script/script.cpp
+++ b/gui/src/script/script.cpp
@@ -1,5 +1,7 @@
 #include "script.h"
 
+#include <QDir>
+#include <QDirIterator>
 #include <QRegularExpression>
 
 namespace SolTrace::GUI::Script {
@@ -188,9 +190,27 @@ bool looks_like_legacy_function_script(QString const& code,
 ScriptPropertyModel::ScriptPropertyModel(QObject* parent)
     : StructTableModel(parent) { }
 
+
+static QStringList get_builtin_scripts() {
+    QStringList files;
+
+    QDirIterator it(":/assets/scripts/", // e.g. ":/scripts"
+                    QStringList() << "*.js",
+                    QDir::Files,
+                    QDirIterator::Subdirectories);
+
+    while (it.hasNext()) {
+        files << it.next();
+    }
+
+    return files;
+}
+
 Script::Script(QObject* parent)
     : QObject { parent }, m_properties { new ScriptPropertyModel(this) } {
     connect(this, &Script::code_changed, this, &Script::parse);
+
+    set_builtin_scripts(get_builtin_scripts());
 }
 
 void Script::set_database(db::Database* db) {

--- a/gui/src/script/script.h
+++ b/gui/src/script/script.h
@@ -123,6 +123,8 @@ class Script : public QObject {
     Q_READONLY_PROPERTY(QStringList, run_errors);
     QOBJECT_READONLY_PROPERTY(ScriptPropertyModel, properties);
 
+    Q_READONLY_PROPERTY(QStringList, builtin_scripts);
+
 public:
     explicit Script(QObject* parent = nullptr);
 

--- a/gui/ui/core/TopBar.qml
+++ b/gui/ui/core/TopBar.qml
@@ -181,6 +181,7 @@ RowLayout {
                                         var file_url = file_settings.file_url_text(modelData)
                                         file_settings.add_files(file_url)
                                         App.file_source.load_url(Qt.url(file_url))
+                                        file_menu.close()
                                     }
                                 }
 

--- a/gui/ui/panels/analyze/AnalyzeFlux.qml
+++ b/gui/ui/panels/analyze/AnalyzeFlux.qml
@@ -29,14 +29,14 @@ Flickable {
             Layout.fillWidth: true
 
             collapsible: true
-            title: "Compute Flux Map"
+            title: "Current Flux Map"
+
+            visible: AppData.flux.current_image.length
 
             Image {
                 Layout.columnSpan: 2
                 Layout.fillWidth: true
                 Layout.preferredHeight: width
-
-                visible: AppData.flux.current_image.length
 
                 source: map_selector.currentIndex == 0 ?
                             AppData.flux.current_image
@@ -57,13 +57,109 @@ Flickable {
 
             STComboBar {
                 id: map_selector
-                visible: AppData.flux.current_image.length
                 Layout.columnSpan: 2
                 Layout.fillWidth: true
                 collapseLabels: AppData.view.left_panel.size === PanelData.Small
                 iconModel: ["\uf00a", "\uf141"]
                 model: ["Bins", "Points"]
             }
+
+            STPropertyLabel {
+                text: "Plotted Power"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.plotted_power
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Peak Flux"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.peak_flux
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Min Flux"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.min_flux
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Average Flux"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.average_flux
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Sigma Flux"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.sigma_flux
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Uniformity"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.uniformity
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Peak Flux Uncert"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.peak_flux_uncertainty
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Average Flux Uncert"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.average_flux_uncertainty
+                font.bold: true
+            }
+
+            STPropertyLabel {
+                text: "Centroid"
+            }
+
+            Label {
+                Layout.fillWidth: true
+                text: root.flux_module.current_flux_stats.centroid
+                font.bold: true
+            }
+        }
+
+        STPropertyPanel {
+            Layout.fillWidth: true
+
+            collapsible: true
+            title: "Compute Flux Map"
 
             STPropertyLabel {
                 text: "Entity"

--- a/gui/ui/panels/script/ScriptInterface.qml
+++ b/gui/ui/panels/script/ScriptInterface.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Controls.Material
 import QtQuick.Effects
 import QtQuick.Layouts
+import QtQuick.Dialogs
 
 import SolTrace
 
@@ -17,14 +18,20 @@ ScrollView {
     contentWidth: availableWidth
 
     function load_script(url) {
+        const requestUrl = String(url).startsWith(":/")
+                         ? "qrc" + String(url)
+                         : url
+
+        console.log("Loading script from:", requestUrl)
         const request = new XMLHttpRequest()
-        request.open("GET", url)
+        request.open("GET", requestUrl)
         request.onreadystatechange = function() {
             if (request.readyState === XMLHttpRequest.DONE) {
                 if (request.status === 0 || request.status === 200) {
+                    console.log("Script ready, installing.", request.responseText)
                     root.module.code = request.responseText
                 } else {
-                    console.warn("Unable to load script", url, request.status)
+                    console.warn("Unable to load script", requestUrl, request.status)
                 }
             }
         }
@@ -57,7 +64,44 @@ ScrollView {
 
                     text: "Load"
 
-                    onClicked: root.load_script("qrc:/assets/scripts/simple.js")
+                    onClicked: file_menu.open()
+
+                    STMenu {
+                        id: file_menu
+                        MenuItem {
+                            text: "Open"
+                            onClicked: openFileDialog.open()
+                        }
+
+                        STMenu {
+                            id: recents_menu
+                            title: qsTr("Builtins")
+                            enabled: recent_instantiator.count > 0
+
+                            Instantiator {
+                                id: recent_instantiator
+                                model: root.module.builtin_scripts
+
+                                delegate: MenuItem {
+                                    implicitWidth: 140
+                                    text: modelData.replace(":/assets/scripts/", "")
+                                    onTriggered: root.load_script(modelData)
+                                }
+                                onObjectAdded: (index, object) => recents_menu.insertItem(index, object)
+                                onObjectRemoved: (index, object) => recents_menu.removeItem(object)
+                            }
+                        }
+                    }
+
+                    FileDialog {
+                        id: openFileDialog
+                        onAccepted: {
+                            var str_file = String(selectedFile)
+
+                            currentFolder = str_file.substring(0, str_file.lastIndexOf("/"))
+                            root.load_script(str_file)
+                        }
+                    }
                 }
 
                 STButton {
@@ -77,7 +121,7 @@ ScrollView {
         STPropertyPanel {
             Layout.fillWidth: true
 
-            title: "Script"
+            title: "Script Parameters"
             collapsible: true
 
             Label {
@@ -86,6 +130,8 @@ ScrollView {
                 Layout.columnSpan: 2
 
                 Layout.row: 0
+
+                elide: Label.ElideRight
 
                 text: root.module.title
                 font.bold: true


### PR DESCRIPTION
 This branch rolls up several GUI fixes and diagnostics:

  - Fixes legacy `.stinput` cylinder imports by translating cylinder origins from the old vertex-based convention to the current centered-cylinder convention used by the native runner.
  - Adds initial GUI Google tests for orientation conversion and database round-tripping, including the shipped power tower surround example.
  - Fixes roll/axis conversion so GUI database transforms materialize correctly into `SimulationData`.
  - Adds richer baked flux map statistics and exposes them through the flux module for UI use.
  - Improves script interface loading so built-in script content is available.
  - Updates sun defaults for pillbox, Gaussian, and CSR values.
  - Improves cylinder surface validation/mesh handling in the GUI.